### PR TITLE
Update configuration defaults

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -20,10 +20,10 @@
     "rejectUnauthorized": true
   },
   "ecclient": {
-    "library": "ECNCT",
     "responseLen": 80,
     "requestLen": 80,
     "debug": false,
-    "pooling": true
+    "pooling": true,
+    "connectionString": "DSN=*LOCAL"
   }
 }


### PR DESCRIPTION
The new `ec-client` allows you to specify the ODBC configuration string and the *Eradani Connect* library is now hard coded to `ECNCT`. Make the following changes to the configuration defaults:

- Add ODBC configuration string
- Remove library name