### PR TITLE
Use "Qualified" for generated RPG data structures

### DIFF
--- a/native/dspjkr.rpgle
+++ b/native/dspjkr.rpgle
@@ -61,17 +61,14 @@
      D Write_Msg1      PR
      D  In_MsgDta                          Like(MsgDta) Const
 
-     D Write_Msg2      PR
-     D  In_HttpSts                         Const Like(R_HttpSts)
-     D  In_Type                            Const Like(R_Type)
-     D  In_Value                           Const Like(R_Value)
+     D Write_RetData   PR
+     D  In_RetData                         Const LikeDS(RetData)
 
-     D Write_Msg3      PR
-     D  In_Joke                            Like(R2_Joke) Const
+     D Write_RetData2  PR
+     D  In_RetData2                        LikeDS(RetData2) Const
 
-     D Write_Msg4      PR
-     D  In_HttpSts                         Const Like(R3_HttpSts)
-     D  In_Error                           Const Like(R3_Error)
+     D Write_RetData3  PR
+     D  In_RetData3                        Const LikeDS(RetData3)
 
      D Write_Excp      PR
      D  In_ProcNm                    32A   Const
@@ -85,7 +82,7 @@
       // Assign Data To Variables
 
          FullCmd = Cmd;
-         D_Ctgry = 'nerdy';
+         Data.D_Ctgry = 'nerdy';
          DataLen = %len(Data);
          DataBuf = Data;
 
@@ -127,14 +124,14 @@
       // Display The Result
 
          RetData = DataBuf;
-         if (R_HttpSts = '200');
-           CallP Write_Msg2(R_HttpSts:R_Type:R_Value);
-           if (R_type <> 'success');
+         if (RetData.R_HttpSts = '200');
+           CallP Write_RetData(RetData);
+           if (RetData.R_Type <> 'success');
              return;
            endif;
          else;
            RetData3 = DataBuf;
-           CallP Write_Msg4(R3_HttpSts:R3_Error);
+           CallP Write_RetData3(RetData3);
            return;
          endif;
 
@@ -159,7 +156,7 @@
                Return;
              Else;
                RetData2 = DataBuf;
-               CallP Write_Msg3(R2_Joke);
+               CallP Write_RetData2(RetData2);
              EndIf;
          EndDo;
 
@@ -190,17 +187,15 @@
      P Write_Msg1      E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg2
+      * Procedure Name:   Write_RetData
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData data structure
       ***-----------------------------------------------------------***
-     P Write_Msg2      B
+     P Write_RetData   B
 
-     D Write_Msg2      PI
-     D  In_HttpSts                         Const Like(R_HttpSts)
-     D  In_Type                            Const Like(R_Type)
-     D  In_Value                           Const Like(R_Value)
+     D Write_RetData   PI
+     D  In_RetData                         Const LikeDS(RetData)
 
      D Text            DS           132
      D  Sts                           3A
@@ -209,63 +204,62 @@
      D  Sep2                          3A   Inz(' - ')
      D  Value                        61A
 
-       Sts = In_HttpSts;
-       Type = In_Type;
-       Value = In_Value;
+       Sts = In_RetData.R_HttpSts;
+       Type = In_RetData.R_Type;
+       Value = In_RetData.R_Value;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg2      E
+     P Write_RetData   E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg3
+      * Procedure Name:   Write_RetData2
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData2 data structure
       ***-----------------------------------------------------------***
-     P Write_Msg3      B
+     P Write_RetData2  B
 
-     D Write_Msg3      PI
-     D  In_Joke                            Like(R2_Joke) Const
+     D Write_RetData2  PI
+     D  In_RetData2                        LikeDS(RetData2) Const
 
      D Text            DS           132
      D  Joke                         80A
 
-       Joke = In_Joke;
+       Joke = In_RetData2.R2_Joke;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg3      E
+     P Write_RetData2  E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg4
+      * Procedure Name:   Write_RetData3
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData3 data structure
       ***-----------------------------------------------------------***
-     P Write_Msg4      B
+     P Write_RetData3  B
 
-     D Write_Msg4      PI
-     D  In_HttpSts                         Const Like(R3_HttpSts)
-     D  In_Error                           Const Like(R3_Error)
+     D Write_RetData3  PI
+     D  In_RetData3                        Const LikeDS(RetData3)
 
      D Text            DS           132
      D  Sts                           3A
      D  Sep                           3A   Inz(' - ')
      D  Error                        77A
 
-       Sts = In_HttpSts;
-       Error = In_Error;
+       Sts = In_RetData3.R3_HttpSts;
+       Error = In_RetData3.R3_Error;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg4      E
+     P Write_RetData3  E
 
       ***-----------------------------------------------------------***
       * Procedure Name:   Write_Excp

--- a/native/dspjkr2.rpgle
+++ b/native/dspjkr2.rpgle
@@ -61,17 +61,14 @@
      D Write_Msg1      PR
      D  In_MsgDta                          Like(MsgDta) Const
 
-     D Write_Msg2      PR
-     D  In_HttpSts                         Const Like(R_HttpSts)
-     D  In_Type                            Const Like(R_Type)
-     D  In_Value                           Const Like(R_Value)
+     D Write_RetData   PR
+     D  In_RetData                         Const LikeDS(RetData)
 
-     D Write_Msg3      PR
-     D  In_Joke                            Like(R2_Joke) Const
+     D Write_RetData2  PR
+     D  In_RetData2                        LikeDS(RetData2) Const
 
-     D Write_Msg4      PR
-     D  In_HttpSts                         Const Like(R3_HttpSts)
-     D  In_Error                           Const Like(R3_Error)
+     D Write_RetData3  PR
+     D  In_RetData3                        Const LikeDS(RetData3)
 
      D Write_Excp      PR
      D  In_ProcNm                    32A   Const
@@ -85,7 +82,7 @@
       // Assign Data To Variables
 
          FullCmd = Cmd;
-         D_Ctgry = 'nerdy';
+         Data.D_Ctgry = 'nerdy';
          DataLen = %len(Data);
          DataBuf = Data;
 
@@ -127,14 +124,14 @@
       // Display The Result
 
          RetData = DataBuf;
-         if (R_HttpSts = '200');
-           CallP Write_Msg2(R_HttpSts:R_Type:R_Value);
-           if (R_type <> 'success');
+         if (RetData.R_HttpSts = '200');
+           CallP Write_RetData(RetData);
+           if (RetData.R_Type <> 'success');
              return;
            endif;
          else;
            RetData3 = DataBuf;
-           CallP Write_Msg4(R3_HttpSts:R3_Error);
+           CallP Write_RetData3(RetData3);
            return;
          endif;
 
@@ -159,7 +156,7 @@
                Return;
              Else;
                RetData2 = DataBuf;
-               CallP Write_Msg3(R2_Joke);
+               CallP Write_RetData2(RetData2);
              EndIf;
          EndDo;
 
@@ -190,17 +187,15 @@
      P Write_Msg1      E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg2
+      * Procedure Name:   Write_RetData
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData data structure
       ***-----------------------------------------------------------***
-     P Write_Msg2      B
+     P Write_RetData   B
 
-     D Write_Msg2      PI
-     D  In_HttpSts                         Const Like(R_HttpSts)
-     D  In_Type                            Const Like(R_Type)
-     D  In_Value                           Const Like(R_Value)
+     D Write_RetData   PI
+     D  In_RetData                         Const LikeDS(RetData)
 
      D Text            DS           132
      D  Sts                           3A
@@ -209,63 +204,62 @@
      D  Sep2                          3A   Inz(' - ')
      D  Value                        61A
 
-       Sts = In_HttpSts;
-       Type = In_Type;
-       Value = In_Value;
+       Sts = In_RetData.R_HttpSts;
+       Type = In_RetData.R_Type;
+       Value = In_RetData.R_Value;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg2      E
+     P Write_RetData   E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg3
+      * Procedure Name:   Write_RetData2
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData2 data structure
       ***-----------------------------------------------------------***
-     P Write_Msg3      B
+     P Write_RetData2  B
 
-     D Write_Msg3      PI
-     D  In_Joke                            Like(R2_Joke) Const
+     D Write_RetData2  PI
+     D  In_RetData2                        LikeDS(RetData2) Const
 
      D Text            DS           132
      D  Joke                         80A
 
-       Joke = In_Joke;
+       Joke = In_RetData2.R2_Joke;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg3      E
+     P Write_RetData2  E
 
       ***-----------------------------------------------------------***
-      * Procedure Name:   Write_Msg4
+      * Procedure Name:   Write_RetData3
       * Purpose.......:   Write Message
       * Returns.......:   None
-      * Parameters....:   Message Data
+      * Parameters....:   RetData3 data structure
       ***-----------------------------------------------------------***
-     P Write_Msg4      B
+     P Write_RetData3  B
 
-     D Write_Msg4      PI
-     D  In_HttpSts                         Const Like(R3_HttpSts)
-     D  In_Error                           Const Like(R3_Error)
+     D Write_RetData3  PI
+     D  In_RetData3                        Const LikeDS(RetData3)
 
      D Text            DS           132
      D  Sts                           3A
      D  Sep                           3A   Inz(' - ')
      D  Error                        77A
 
-       Sts = In_HttpSts;
-       Error = In_Error;
+       Sts = In_RetData3.R3_HttpSts;
+       Error = In_RetData3.R3_Error;
 
        Write QSysPrt Text;
 
        Return;
 
-     P Write_Msg4      E
+     P Write_RetData3  E
 
       ***-----------------------------------------------------------***
       * Procedure Name:   Write_Excp

--- a/native/dspwfr.rpgle
+++ b/native/dspwfr.rpgle
@@ -89,8 +89,8 @@
       // Assign Data To Variables
 
          FullCmd = Cmd;
-         Lat     = In_Lat;
-         Lon     = In_Lon;
+         Location.Lat = In_Lat;
+         Location.Lon = In_Lon;
          DataLen = %len(Location);
          DataBuf = Location;
 
@@ -134,7 +134,7 @@
          Result = DataBuf;
          CallP Write_Result(Result);
 
-         HttpStatusN = %Dec(HttpStatus:10:0);
+         HttpStatusN = %Dec(Result.HttpStatus:10:0);
          If (HttpStatusN < 200) or (HttpStatusN >= 300);
            Return;
          EndIf;

--- a/native/dspwfr2.rpgle
+++ b/native/dspwfr2.rpgle
@@ -89,8 +89,8 @@
       // Assign Data To Variables
 
          FullCmd = Cmd;
-         Lat     = In_Lat;
-         Lon     = In_Lon;
+         Location.Lat = In_Lat;
+         Location.Lon = In_Lon;
          DataLen = %len(Location);
          DataBuf = Location;
 
@@ -134,7 +134,7 @@
          Result = DataBuf;
          CallP Write_Result(Result);
 
-         HttpStatusN = %Dec(HttpStatus:10:0);
+         HttpStatusN = %Dec(Result.HttpStatus:10:0);
          If (HttpStatusN < 200) or (HttpStatusN >= 300);
            Return;
          EndIf;

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       }
     },
     "@eradani-inc/ec-generate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@eradani-inc/ec-generate/-/ec-generate-3.3.0.tgz",
-      "integrity": "sha512-xHZ5WQUbwGIsuJ6EWIM2Y+MEQheZBpfJXOA7Cp4o05b7emDPMQGvDqGDRur8zyvNoXRvM8FLUM0UWLjsYqpmag==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eradani-inc/ec-generate/-/ec-generate-3.3.1.tgz",
+      "integrity": "sha512-z7R9uJBgWbBhY/PDO8Mu+X7QJAtq82Fjmm6HvjX3kS+0I7150eBt+xrsATLgwA9zroL1iVAByshRk5oATE9aiA==",
       "dev": true,
       "requires": {
         "yargs": "^15.3.1"
@@ -1485,12 +1485,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.20"
   },
   "devDependencies": {
-    "@eradani-inc/ec-generate": "^3.3.0",
+    "@eradani-inc/ec-generate": "^3.3.1",
     "eslint": "^7.6.0",
     "prettier": "^2.0.5"
   }


### PR DESCRIPTION
Update to the version of the generator that generates RPG data structures using the *Qualified* keyword. Then update the RPG sample code to fully qualify data structure fields.

Closes #6 